### PR TITLE
Fix PA Stats Server client mod lobbyId spamming and PA Chat auto status update scenes

### DIFF
--- a/pa_stats/pa_stats_loader.js
+++ b/pa_stats/pa_stats_loader.js
@@ -33,6 +33,14 @@ var paStatsBaseDir = typeof statsDevelopmentNeverUseThisNameAnywhereElseIDareYou
 	addSceneEntry('live_game_options_bar', "https://dfpsrd4q7p23m.cloudfront.net/mods/pachat/live_game_options_bar.css");
 	addSceneEntry('live_game_options_bar', "https://dfpsrd4q7p23m.cloudfront.net/mods/pachat/live_game_options_bar.js");
 
+	addSceneEntry('start', "https://dfpsrd4q7p23m.cloudfront.net/mods/pachat/start.js");
+	addSceneEntry('matchmaking', "https://dfpsrd4q7p23m.cloudfront.net/mods/pachat/matchmaking.js");
+	addSceneEntry('new_game_ladder', "https://dfpsrd4q7p23m.cloudfront.net/mods/pachat/new_game_ladder.js");
+	addSceneEntry('server_browser', "https://dfpsrd4q7p23m.cloudfront.net/mods/pachat/server_browser.js");
+	addSceneEntry('new_game', "https://dfpsrd4q7p23m.cloudfront.net/mods/pachat/new_game.js");
+	addSceneEntry('live_game', "https://dfpsrd4q7p23m.cloudfront.net/mods/pachat/live_game.js");
+	addSceneEntry('system_editor', "https://dfpsrd4q7p23m.cloudfront.net/mods/pachat/system_editor.js");
+
 	// End of PA Chat
 	
 	if (typeof paStatsGlobal === 'undefined') {

--- a/pa_stats/scenes/game_over.js
+++ b/pa_stats/scenes/game_over.js
@@ -17,7 +17,7 @@
 		});
 	};
 	
-	$('.div_stats_panel_options').prepend('<!-- ko if: model.hasPaStatsGame --><div><input style="background-image: url(http://ns393951.ip-176-31-115.eu/mod/icon.png); background-repeat: no-repeat; padding-right: 85px; background-position: 150px 2px; background-size: 50px 50px" type="button" value="Details on" id="pa_stats_btt" class="" data-bind="click: openPaStatsGame, click_sound: \'default\', rollover_sound: \'default\'" /></div><!-- /ko -->');
+	$('.div_stats_panel_options').prepend('<!-- ko if: model.hasPaStatsGame --><div><input style="background-image: url(http://pastats.com/mod/icon.png); background-repeat: no-repeat; padding-right: 85px; background-position: 150px 2px; background-size: 50px 50px" type="button" value="Details on" id="pa_stats_btt" class="" data-bind="click: openPaStatsGame, click_sound: \'default\', rollover_sound: \'default\'" /></div><!-- /ko -->');
 	
 	if (decode(localStorage[paStatsGlobal.wantsToSendKey])) {
 		

--- a/pa_stats/scenes/new_game_server.js
+++ b/pa_stats/scenes/new_game_server.js
@@ -17,14 +17,14 @@ var paStatsServerLoaded;
 	
 	model.paStatsServer_isHost = ko.computed( function()
 	{
-	   return model.isGameCreator() && model.paStatsServer_isActuallyLoaded(); 
+		return model.isGameCreator() && model.paStatsServer_isActuallyLoaded(); 
 	});
 
 	var paStatsServer_checkLoaded = function()
 	{
 		api.mods.getMountedMods( 'server', function ( mods )
 		{
-			var loaded =  _.intersection( _.pluck( mods, 'identifier' ), [ 'info.nanodesu.pastats.server.server', 'info.nanodesu.pastats.server.server-TEST' ] ).length > 0;
+			var loaded = _.intersection( _.pluck( mods, 'identifier' ), [ 'info.nanodesu.pastats.server.server', 'info.nanodesu.pastats.server.server-TEST' ] ).length > 0;
 			
 			model.paStatsServer_isActuallyLoaded( loaded );
 		});
@@ -50,14 +50,17 @@ var paStatsServerLoaded;
 
 	var oldChatHandler = handlers.chat_message;
 	
-	handlers.chat_message = function(payload){
+	handlers.chat_message = function(payload)
+	{
 		
-		if ( model.paStatsServer_isHost() )
+		if (payload.message.indexOf('"id":"pastats-custom-message"') !== -1)
 		{
-			return;
-		}
+	
+			if ( model.paStatsServer_isHost() )
+			{
+				return;
+			}
 		
-		if (payload.message.indexOf('"id":"pastats-custom-message"') !== -1) {
 			var data = JSON.parse(payload.message);
 			if (decode(localStorage['lobbyId']) !== data.lobbyId) {
 				localStorage['lobbyId'] = encode(data.lobbyId);

--- a/pa_stats/scenes/new_game_server.js
+++ b/pa_stats/scenes/new_game_server.js
@@ -1,35 +1,102 @@
-console.log("loaded new_game for server PA Stats");
+var paStatsServerLoaded;
 
 (function() {
+
+
+	if ( paStatsServerLoaded )
+	{
+		console.log( "PA Stats new_game_server.js already loaded" );
+		return;
+	}
+	
+	paStatsServerLoaded = true;
+
+	console.log("PA Stats new_game_server.js");
+
+	model.paStatsServer_isActuallyLoaded = ko.observable( false );
+	
+	model.paStatsServer_isHost = ko.computed( function()
+	{
+	   return model.isGameCreator() && model.paStatsServer_isActuallyLoaded(); 
+	});
+
+	var paStatsServer_checkLoaded = function()
+	{
+		api.mods.getMountedMods( 'server', function ( mods )
+		{
+			var loaded =  _.intersection( _.pluck( mods, 'identifier' ), [ 'info.nanodesu.pastats.server.server', 'info.nanodesu.pastats.server.server-TEST' ] ).length > 0;
+			
+			model.paStatsServer_isActuallyLoaded( loaded );
+		});
+	}
+	  
+// once mod data is sent check if pa stats server is actually loaded
+	
+	if ( window.scene_server_mod_list && window.scene_server_mod_list.new_game )
+	{
+		paStatsServer_checkLoaded(); 
+	}
+	else
+	{
+		var paStatsServer_server_mod_info_updated_handler = handlers.server_mod_info_updated;
+   
+		handlers.server_mod_info_updated = function( payload )
+		{
+			paStatsServer_server_mod_info_updated_handler( payload );
+			
+			paStatsServer_checkLoaded();
+		}
+	}
+
 	var oldChatHandler = handlers.chat_message;
 	
-	handlers.chat_message = function(payload) {
+	handlers.chat_message = function(payload){
+		
+		if ( model.paStatsServer_isHost() )
+		{
+			return;
+		}
+		
 		if (payload.message.indexOf('"id":"pastats-custom-message"') !== -1) {
 			var data = JSON.parse(payload.message);
 			if (decode(localStorage['lobbyId']) !== data.lobbyId) {
 				localStorage['lobbyId'] = encode(data.lobbyId);
 				localStorage[paStatsGlobal.isRankedGameKey] = encode(false);
 				localStorage[paStatsGlobal.isLocalGame] = encode(false);
-				console.log("set lobbyId from custom chat message: "+data.lobbyId);
+				console.log("PA Stats new_game_server.js received lobbyId: "+ data.lobbyId);
 			}
 		} else {
 			oldChatHandler(payload);
 		}
 	};
 	
-	var sendLobbyIdChat = function(lobbyId) {
-		var msg = {};
-		msg.id = "pastats-custom-message";
-		msg.lobbyId = lobbyId;
-		model.send_message("chat_message", {message: JSON.stringify(msg)});
-	};
-	
-	var spamLobbyIdInfoIfHost = function() {
-		if (model.isGameCreator()) {
-			sendLobbyIdChat(decode(localStorage['lobbyId']));
-		}
-		setTimeout(spamLobbyIdInfoIfHost, 1000);
-	};
-	
-	spamLobbyIdInfoIfHost();
+	model.paStatsServer_isHost.subscribe( function( isHost )
+	{
+
+		if ( isHost )
+		{
+
+			var paStatsServer_players_handler = handlers.players;
+			
+			handlers.players = function( payload )
+			{
+				paStatsServer_players_handler( payload );
+		
+				if ( ! _.isEmpty( payload ) )
+				{
+
+					var lobbyId = decode( localStorage['lobbyId'] );
+					
+					console.log("PA Stats new_game_server.js sending lobbyId: " + lobbyId );
+
+					var data = {};
+					data.id = "pastats-custom-message";
+					data.lobbyId = lobbyId ;
+					model.send_message("chat_message", { message: JSON.stringify(data) } );
+				}		 
+			}
+				
+		}		 
+	});
+		
 }());


### PR DESCRIPTION
Prevent chat spamming of lobbyID by the PA Stats Server client mod when
the server mod is not actually loaded:

- check if PA Stats Server server mod is actually loaded
- send lobbyID when players or player status changes

The PA Stats Server server mod may not load when server mods are
inherited from a previous game (known Uber issue).

Adds PA Chat scenes for auto status updates.